### PR TITLE
Update TwitterOAuth.php

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -220,10 +220,12 @@ class TwitterOAuth extends Config
     /**
      * Return a response with in its body a `processing_info` object containing the state of the uploaded file.
      *
-     * @param $mediaIdString
+     * @param string $mediaIdString
+     *
      * @return array|object
      */
-    public function getUploadFileState($mediaIdString) {
+    public function getUploadFileState($mediaIdString) 
+    {
       return $this->http('GET', self::UPLOAD_HOST, 'media/upload', [
         'command' => 'STATUS',
         'media_id' => $mediaIdString

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -216,6 +216,19 @@ class TwitterOAuth extends Config
     {
         return $this->http('PUT', self::API_HOST, $path, $parameters);
     }
+    
+    /**
+     * Return a response with in its body a `processing_info` object containing the state of the uploaded file.
+     *
+     * @param $mediaIdString
+     * @return array|object
+     */
+    public function getUploadFileState($mediaIdString) {
+      return $this->http('GET', self::UPLOAD_HOST, 'media/upload', [
+        'command' => 'STATUS',
+        'media_id' => $mediaIdString
+      ]);
+    }
 
     /**
      * Upload media to upload.twitter.com.


### PR DESCRIPTION
Adding this function in order to be able to check the status of an asynchronous video upload from outside the TwitterOAuth class.
I had issues when uploading videos because the uploadMediaChunked function was rendering this object: 
class stdClass#463 (5) {
  public $media_id =>
  int(887333631232024577)
  public $media_id_string =>
  string(18) "887333631232024577"
  public $size =>
  int(11938010)
  public $expires_after_secs =>
  int(15552000)
  public $processing_info =>
  class stdClass#465 (2) {
    public $state =>
    string(7) "pending"
    public $check_after_secs =>
    int(5)
  }
}
And I basically had no way to check the `state`of this uploaded video from outside this class even though I needed to know when I could post it to my twitter profile.